### PR TITLE
Refactor zero address checks

### DIFF
--- a/src/PHTR/Ephtr.ts
+++ b/src/PHTR/Ephtr.ts
@@ -6,6 +6,7 @@ import { Emissions } from "../../generated/ephtr/Emissions"
 import { createOrLoadIndexEntity, createOrLoadIndexAssetEntity, createOrLoadIndexAccountEntity, createOrLoadHistoricalAccountBalanceEntity, createOrLoadAccountEntity, createOrLoadHistoricalPriceEntity, createOrLoadChainIDToAssetMappingEntity } from "../EntityCreation"
 import { saveHistoricalData } from "../v2/ConfigBuilder"
 import { getTokenInfo } from "../v1/IndexFactory"
+import { ZERO_ADDRESS } from "../constants"
 
 export function handleTransfer(event: TransferEvent): void {
     let index = createOrLoadIndexEntity(event.address)
@@ -34,7 +35,7 @@ export function handleTransfer(event: TransferEvent): void {
         index.save()
     }
     let scalar = new BigDecimal(BigInt.fromI32(10).pow(u8(index.decimals)))
-    if (event.params.from != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+    if (!event.params.from.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
         let fromAccount = createOrLoadIndexAccountEntity(event.address, event.params.from)
         createOrLoadAccountEntity(event.params.from)
         fromAccount.balance = fromAccount.balance.minus(new BigDecimal(event.params.value).div(scalar))
@@ -46,10 +47,10 @@ export function handleTransfer(event: TransferEvent): void {
         historicalAccountBalanceEntity.balance = fromAccount.balance
         historicalAccountBalanceEntity.save()
     }
-    if (event.params.from == Address.fromString('0x0000000000000000000000000000000000000000') && event.params.to != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+    if (event.params.from.equals(Address.fromString(ZERO_ADDRESS)) && !event.params.to.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
         index.totalSupply = index.totalSupply.plus(new BigDecimal(event.params.value).div(scalar))
     }
-    if (event.params.to != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+    if (!event.params.to.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
         let toAccount = createOrLoadIndexAccountEntity(event.address, event.params.to)
         createOrLoadAccountEntity(event.params.to)
         if (toAccount.balance == BigDecimal.zero()) {
@@ -61,7 +62,7 @@ export function handleTransfer(event: TransferEvent): void {
         historicalAccountBalanceEntity.balance = toAccount.balance
         historicalAccountBalanceEntity.save()
     }
-    if (event.params.to == Address.fromString('0x0000000000000000000000000000000000000000') && event.params.from != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+    if (event.params.to.equals(Address.fromString(ZERO_ADDRESS)) && !event.params.from.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
         index.totalSupply = index.totalSupply.minus(new BigDecimal(event.params.value).div(scalar))
     }
     index.save()

--- a/src/v1/IndexFactory.ts
+++ b/src/v1/IndexFactory.ts
@@ -10,6 +10,7 @@ import { createOrLoadChainIDToAssetMappingEntity, createOrLoadIndexAssetEntity, 
 import { ERC20 } from "../../generated/IndexFactoryV1/ERC20"
 import { MakerERC20 } from "../../generated/IndexFactoryV1/MakerERC20"
 import { IndexAsset } from "../../generated/schema"
+import { ZERO_ADDRESS } from "../constants"
 
 export function handleManagedIndexCreated(
   event: ManagedIndexCreatedEvent
@@ -45,7 +46,7 @@ export function handleManagedIndexCreated(
     let token = event.params._assets[i]
     let weight = event.params._weights[i]
     let vtokenAddress = vaultFactoryContract.bind(vTokenFactory).vTokenOf(token)
-    if (vtokenAddress != Address.fromString("0x0000000000000000000000000000000000000000")) {
+    if (!vtokenAddress.equals(Address.fromString(ZERO_ADDRESS))) {
       let context = new DataSourceContext()
       context.setBytes('assetAddress', token)
       context.setBytes('indexAddress', event.params.index)

--- a/src/v1/IndexToken.ts
+++ b/src/v1/IndexToken.ts
@@ -7,12 +7,13 @@ import {
 import { createOrLoadIndexEntity, createOrLoadIndexAssetEntity, createOrLoadIndexAccountEntity, createOrLoadHistoricalAccountBalanceEntity, createOrLoadAccountEntity, createOrLoadChainIDToAssetMappingEntity } from "../EntityCreation"
 import { getTokenInfo } from "./IndexFactory"
 import { saveHistoricalData } from "../v2/ConfigBuilder"
+import { ZERO_ADDRESS } from "../constants"
 
 
 export function handleTransfer(event: TransferEvent): void {
   let index = createOrLoadIndexEntity(event.address)
   let scalar = new BigDecimal(BigInt.fromI32(10).pow(u8(index.decimals)))
-  if (event.params.from != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+  if (!event.params.from.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
     let fromAccount = createOrLoadIndexAccountEntity(event.address, event.params.from)
     createOrLoadAccountEntity(event.params.from)
     fromAccount.balance = fromAccount.balance.minus(new BigDecimal(event.params.value).div(scalar))
@@ -24,10 +25,10 @@ export function handleTransfer(event: TransferEvent): void {
     historicalAccountBalanceEntity.balance = fromAccount.balance
     historicalAccountBalanceEntity.save()
   }
-  if (event.params.from == Address.fromString('0x0000000000000000000000000000000000000000') && event.params.to != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+  if (event.params.from.equals(Address.fromString(ZERO_ADDRESS)) && !event.params.to.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
     index.totalSupply = index.totalSupply.plus(new BigDecimal(event.params.value).div(scalar))
   }
-  if (event.params.to != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+  if (!event.params.to.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
     let toAccount = createOrLoadIndexAccountEntity(event.address, event.params.to)
     createOrLoadAccountEntity(event.params.to)
     if (toAccount.balance == BigDecimal.zero()) {
@@ -40,7 +41,7 @@ export function handleTransfer(event: TransferEvent): void {
     historicalAccountBalanceEntity.balance = toAccount.balance
     historicalAccountBalanceEntity.save()
   }
-  if (event.params.to == Address.fromString('0x0000000000000000000000000000000000000000') && event.params.from != Address.fromString('0x0000000000000000000000000000000000000000') && event.params.value > BigInt.zero()) {
+  if (event.params.to.equals(Address.fromString(ZERO_ADDRESS)) && !event.params.from.equals(Address.fromString(ZERO_ADDRESS)) && event.params.value > BigInt.zero()) {
     index.totalSupply = index.totalSupply.minus(new BigDecimal(event.params.value).div(scalar))
   }
 

--- a/src/v2/IndexFactory.ts
+++ b/src/v2/IndexFactory.ts
@@ -4,6 +4,7 @@ import { Governance as GovernanceTemplate, IndexTokenV2 as indexTemplate } from 
 import { Address, BigDecimal, BigInt, Bytes, DataSourceContext, dataSource, log } from "@graphprotocol/graph-ts"
 import { IndexTokenV2 } from "../../generated/IndexFactoryV2/IndexTokenV2"
 import { getTokenInfo } from "../v1/IndexFactory"
+import { ZERO_ADDRESS } from "../constants"
 
 
 export function handleIndexDeployed(event: DeployedEvent): void {
@@ -25,7 +26,7 @@ export function handleIndexDeployed(event: DeployedEvent): void {
     index.k = BigInt.fromI32(1).times(BigInt.fromI32(10).pow(18))
     index.totalFees = BigDecimal.zero()
     let indexAssetEntity = createOrLoadIndexAssetEntity(event.params.index, event.params.reserve, chainID)
-    if (event.params.reserve != Address.fromString('0x0000000000000000000000000000000000000000')) {
+    if (!event.params.reserve.equals(Address.fromString(ZERO_ADDRESS))) {
         getTokenInfo(indexAssetEntity, event.params.reserve)
     }
     else {

--- a/src/v3/IndexFactory.ts
+++ b/src/v3/IndexFactory.ts
@@ -14,7 +14,7 @@ import {
 	createOrLoadIndexEntity,
 } from "../EntityCreation";
 
-import { ONE, WAD, ZERO } from "../constants";
+import { ONE, WAD, ZERO, ZERO_ADDRESS } from "../constants";
 import { getTokenInfo } from "../v1/IndexFactory";
 
 export function handleIndexDeployed(event: DeployedEvent): void {
@@ -42,10 +42,9 @@ export function handleIndexDeployed(event: DeployedEvent): void {
 		event.params.reserve,
 		chainID,
 	);
-	if (
-		event.params.reserve ==
-		Address.fromString("0x0000000000000000000000000000000000000000")
-	) {
+        if (
+                event.params.reserve.equals(Address.fromString(ZERO_ADDRESS))
+        ) {
 		const nativeAssetInfo = dataSource.context().get("nativeAsset")!;
 		indexAssetEntity.name = nativeAssetInfo.toArray()[0].toString();
 		indexAssetEntity.symbol = nativeAssetInfo.toArray()[1].toString();


### PR DESCRIPTION
## Summary
- remove hard-coded zero address strings in event handlers
- use `Address.fromString(ZERO_ADDRESS)` instead
- compare addresses with `.equals()`

## Testing
- `npm test` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684769976d04832d8e6f85ddfeae3b09