### PR TITLE
Fix JooceReward address comparison

### DIFF
--- a/src/JOOCE/JooceReward.ts
+++ b/src/JOOCE/JooceReward.ts
@@ -4,7 +4,7 @@ import { createOrLoadJooceRewardEntity } from "../EntityCreation"
 
 export function handleJooceTransfer(event: TransferEvent): void {
     log.debug("HandleJooceTransfer event hash: {} from: {} logIndex: {} to: {}", [event.transaction.hash.toHexString(), event.params.from.toHexString(), event.logIndex.toHexString(), event.params.to.toHexString()])
-    if (event.params.to == Address.fromString("0x004fd4bcc4c9989c18a1a1463241b7ccec9f7051")) {
+    if (event.params.to.equals(Address.fromString("0x004fd4bcc4c9989c18a1a1463241b7ccec9f7051"))) {
     createOrLoadJooceRewardEntity(event.transaction.hash,event.logIndex,event.block.timestamp,event.params.from, event.params.to,event.params.value)
     }
 }


### PR DESCRIPTION
## Summary
- update JooceReward handler to use `equals` when checking `to` address

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847811844d0832d9d5cb9cc9f2f08e7